### PR TITLE
Allow dynamic timestep resolution for `bcm`, don't save otherwise

### DIFF
--- a/cogsworth/galaxy.py
+++ b/cogsworth/galaxy.py
@@ -81,7 +81,7 @@ class Galaxy():
         return self.size
 
     def __repr__(self):
-        return f"<{self.__class__.__name__}, size={self.size}>"
+        return f"<{self.__class__.__name__}, size={len(self)}>"
 
     def __getitem__(self, ind):
         # ensure indexing with the right type

--- a/cogsworth/pop.py
+++ b/cogsworth/pop.py
@@ -62,6 +62,10 @@ class Population():
         Size of timesteps to use in galactic evolution, by default 1*u.Myr
     BSE_settings : `dict`, optional
         Any BSE settings to pass to COSMIC
+    bcm_timestep_conditions : List of lists, optional
+        Any timestep conditions to pass to COSMIC evolution. This will affect the rows that are output in the
+        the BCM table, by default only the first and last timesteps are output. For more details check out the
+        `relevant COSMIC docs <https://cosmic-popsynth.github.io/COSMIC/examples/index.html#dynamically-set-time-resolution-for-bcm-array>`_
     sampling_params : `dict`, optional
         Any additional parameters to pass to the COSMIC sampling (see
         :meth:`~cosmic.sample.sampler.independent.get_independent_sampler`)
@@ -115,7 +119,7 @@ class Population():
                  final_kstar2=list(range(16)), galaxy_model=galaxy.Wagg2022, galaxy_params={},
                  galactic_potential=gp.MilkyWayPotential(), v_dispersion=5 * u.km / u.s,
                  max_ev_time=12.0*u.Gyr, timestep_size=1 * u.Myr, BSE_settings={}, sampling_params={},
-                 store_entire_orbits=True):
+                 bcm_timestep_conditions=None, store_entire_orbits=True):
 
         # require a sensible number of binaries if you are not targetting total mass
         if not ("sampling_target" in sampling_params and sampling_params["sampling_target"] == "total_mass"):
@@ -183,6 +187,7 @@ class Population():
         self.sampling_params = {'primary_model': 'kroupa01', 'ecc_model': 'sana12', 'porb_model': 'sana12',
                                 'qmin': -1, 'keep_singles': False}
         self.sampling_params.update(sampling_params)
+        self.bcm_timestep_conditions = bcm_timestep_conditions
 
     def __repr__(self):
         if self._orbits is None:

--- a/cogsworth/tests/test_classify.py
+++ b/cogsworth/tests/test_classify.py
@@ -32,7 +32,7 @@ class Test(unittest.TestCase):
 
     def test_x_rays(self):
         """Test x-ray luminosity calculation"""
-        p = cogsworth.pop.Population(10, final_kstar1=[13, 14])
+        p = cogsworth.pop.Population(10, final_kstar1=[13, 14], bcm_timestep_conditions=[['dtp=100000.0']])
         bcm = p.bcm.drop_duplicates(subset="bin_num", keep='last')
         it_broke = False
         try:

--- a/cogsworth/tests/test_galaxy.py
+++ b/cogsworth/tests/test_galaxy.py
@@ -90,6 +90,7 @@ class Test(unittest.TestCase):
         it_broke = False
         try:
             g = galaxy.Wagg2022(size=10, immediately_sample=False)
+            len(g)
             g.components
             g.component_masses
             g.tau

--- a/cogsworth/tests/test_plot.py
+++ b/cogsworth/tests/test_plot.py
@@ -1,0 +1,18 @@
+import numpy as np
+import pandas as pd
+import unittest
+import cogsworth
+
+
+class Test(unittest.TestCase):
+    def test_plot_cmd(self):
+        p = cogsworth.pop.Population(2)
+        p.sample_initial_binaries()
+        p.perform_stellar_evolution()
+
+        p._observables = pd.DataFrame({"G_abs_1": np.ones(len(p)), "BP_app_1": np.ones(len(p)),
+                                       "RP_app_1": np.ones(len(p)),
+                                       "G_abs_2": np.ones(len(p)), "BP_app_2": np.ones(len(p)),
+                                       "RP_app_2": np.ones(len(p)),
+                                       "secondary_brighter": np.zeros(len(p)).astype(bool)})
+        cogsworth.plot.plot_cmd(p, show=False)

--- a/cogsworth/tests/test_pop.py
+++ b/cogsworth/tests/test_pop.py
@@ -25,7 +25,7 @@ class Test(unittest.TestCase):
 
     def test_io(self):
         """Check that a population can be saved and re-loaded"""
-        p = pop.Population(2)
+        p = pop.Population(2, bcm_timestep_conditions=[['dtp=100000.0']])
         p.create_population()
 
         p.save("testing-pop-io", overwrite=True)
@@ -195,7 +195,7 @@ class Test(unittest.TestCase):
     @pytest.mark.filterwarnings("ignore:.*duplicate")
     def test_indexing(self):
         """Ensure that indexing works as expected for proper types"""
-        p = pop.Population(10)
+        p = pop.Population(10, bcm_timestep_conditions=[['dtp=100000.0']])
         p.create_population()
         inds = [int(np.random.choice(p.bin_nums, replace=False)),
                 np.random.choice(p.bin_nums, size=4, replace=False),
@@ -349,7 +349,7 @@ class Test(unittest.TestCase):
 
     def test_translation(self):
         """Ensure that COSMIC tables are being translated properly"""
-        p = pop.Population(10)
+        p = pop.Population(10, bcm_timestep_conditions=[['dtp=100000.0']])
         p.perform_stellar_evolution()
         p.translate_tables(replace_columns=False, label_type="short")
 

--- a/docs/tutorials/basics/outputs.ipynb
+++ b/docs/tutorials/basics/outputs.ipynb
@@ -6260,7 +6260,7 @@
     "``bcm`` - User-specified timestep table\n",
     "---------------------------------------\n",
     "\n",
-    "The columns here are identical to the ``bpp`` table and by default, this table will only include timesteps for the start and end of the evolution of each binary. However, you can use ``timestep_conditions`` to define particular conditions that can result in finer resolution timestep conditions being printed. For example you could print extra timesteps for any binary that is transferring mass onto a compact object to look at X-ray binaries in more detail.\n",
+    "The columns here are identical to the ``bpp`` table and by default, this table will only include timesteps for the start and end of the evolution of each binary (and thus we don't save it in ``cogsworth`` in these cases). However, you can use ``bcm_timestep_conditions`` to define particular conditions that can result in finer resolution timestep conditions being printed. For example you could print extra timesteps for any binary that is transferring mass onto a compact object to look at X-ray binaries in more detail.\n",
     "\n",
     "For more details on this check out the ``cogsworth`` `tutorial on re-running binaries <../output_analysis/rerun.ipynb>`_ and the ``COSMIC`` `docs about the setting the time resolution dynamically <https://cosmic-popsynth.github.io/COSMIC/examples/index.html#dynamically-set-time-resolution-for-bcm-array>`_."
    ]


### PR DESCRIPTION
This will fix #88 