### PR TITLE
BUG: fix duplicate timestep bug in kicked orbits

### DIFF
--- a/cogsworth/tests/test_kicks.py
+++ b/cogsworth/tests/test_kicks.py
@@ -1,0 +1,37 @@
+import unittest
+import cogsworth
+import numpy as np
+
+
+class Test(unittest.TestCase):
+    def test_duplicated_timesteps(self):
+        """Ensure that the locations at timesteps in orbits are never duplicated
+
+        Motivated by a bug that occurred during the stitching of timesteps in the orbit of a kicked binary,
+        so that the orbit was not continuous. This test ensures that the orbit is continuous and only tests
+        the kicked binaries since the rest are unaffected"""
+
+        # create a population likely to have lots of disruptions
+        p = cogsworth.pop.Population(100, final_kstar1=[13, 14], final_kstar2=[13, 14])
+        p.create_population()
+
+        sn_1 = np.isin(p.bin_nums, p.bpp[p.bpp["evol_type"] == 15]["bin_num"].unique())
+        sn_2 = np.isin(p.bin_nums, p.bpp[p.bpp["evol_type"] == 16]["bin_num"].unique())
+
+        primary_kick_orbits = p.primary_orbits[sn_1 | sn_2]
+        secondary_kick_orbits = p.secondary_orbits[sn_1 | sn_2]
+        kick_orbits = np.concatenate((primary_kick_orbits, secondary_kick_orbits))
+
+        valid_orbit = np.repeat(True, len(kick_orbits))
+        for i in range(len(kick_orbits)):
+            orbit = kick_orbits[i]
+            if np.any(np.diff(orbit.t) == 0.0):
+                valid_orbit[i] = False
+            if np.any(np.diff(orbit.x) == 0.0):
+                valid_orbit[i] = False
+            if np.any(np.diff(orbit.y) == 0.0):
+                valid_orbit[i] = False
+            if np.any(np.diff(orbit.z) == 0.0):
+                valid_orbit[i] = False
+
+        self.assertTrue(np.all(valid_orbit))


### PR DESCRIPTION
Before this fix all orbits that received a kick were offset by one timestep due to some problems when restitching the full orbit together.

This became apparent when somehow kicked systems were lagging slightly behind their unkicked counterparts oops.

All fixed and a test to ensure it doesn't happen again!