### PR TITLE
Save binary inclination and phase at each SN to ensure reproducibility

### DIFF
--- a/cogsworth/events.py
+++ b/cogsworth/events.py
@@ -39,17 +39,16 @@ def identify_events(p):
 
         bpp = full_bpp.loc[[bin_num]]
         kick_info = full_kick_info.loc[[bin_num]]
+        initC = p.initC.loc[[bin_num]]
 
         # for primaries and bound binaries we just need a simple list
         primary_events_list[i] = [{
             "time": bpp.iloc[j]["tphys"] * u.Myr,
-            "m_1": bpp.iloc[j]["mass_1"] * u.Msun,
-            "m_2": bpp.iloc[j]["mass_2"] * u.Msun,
-            "a": bpp.iloc[j]["sep"] * u.Rsun,
-            "ecc": bpp.iloc[j]["ecc"],
             "delta_v_sys_xyz": [kick_info.iloc[j]["delta_vsysx_1"],
                                 kick_info.iloc[j]["delta_vsysy_1"],
-                                kick_info.iloc[j]["delta_vsysz_1"]] * u.km / u.s
+                                kick_info.iloc[j]["delta_vsysz_1"]] * u.km / u.s,
+            "inc": initC[f"inc_sn_{j + 1:0d}"] if f"inc_sn_{j + 1:0d}" in initC else None,
+            "phase": initC[f"phase_sn_{j + 1:0d}"] if f"phase_sn_{j + 1:0d}" in initC else None,
         } for j in range(len(kick_info))]
 
         # iterate over the kick file and store the relevant information (for both if disruption will occur)
@@ -60,12 +59,10 @@ def identify_events(p):
                 col_suffix = "_1" if kick_info.iloc[j]["disrupted"] == 0.0 else "_2"
                 secondary_events_list[i].append({
                     "time": bpp.iloc[j]["tphys"] * u.Myr,
-                    "m_1": bpp.iloc[j]["mass_1"] * u.Msun,
-                    "m_2": bpp.iloc[j]["mass_2"] * u.Msun,
-                    "a": bpp.iloc[j]["sep"] * u.Rsun,
-                    "ecc": bpp.iloc[j]["ecc"],
                     "delta_v_sys_xyz": [kick_info.iloc[j][f'delta_vsysx{col_suffix}'],
                                         kick_info.iloc[j][f'delta_vsysy{col_suffix}'],
-                                        kick_info.iloc[j][f'delta_vsysz{col_suffix}']] * u.km / u.s
+                                        kick_info.iloc[j][f'delta_vsysz{col_suffix}']] * u.km / u.s,
+                    "inc": initC[f"inc_sn_{j + 1:0d}"] if f"inc_sn_{j + 1:0d}" in initC else None,
+                    "phase": initC[f"phase_sn_{j + 1:0d}"] if f"phase_sn_{j + 1:0d}" in initC else None,
                 })
     return primary_events_list, secondary_events_list

--- a/cogsworth/events.py
+++ b/cogsworth/events.py
@@ -39,7 +39,7 @@ def identify_events(p):
 
         bpp = full_bpp.loc[[bin_num]]
         kick_info = full_kick_info.loc[[bin_num]]
-        initC = p.initC.loc[[bin_num]]
+        initC = p.initC.loc[bin_num]
 
         # for primaries and bound binaries we just need a simple list
         primary_events_list[i] = [{

--- a/cogsworth/kicks.py
+++ b/cogsworth/kicks.py
@@ -131,7 +131,7 @@ def integrate_orbit_with_events(w0, t1, t2, dt, potential=gp.MilkyWayPotential()
 
                 # calculate the kick differential
                 kick_differential = get_kick_differential(delta_v_sys_xyz=event["delta_v_sys_xyz"],
-                                                          m_1=event["m_1"], m_2=event["m_2"], a=event["a"])
+                                                          phase=event["phase"], inclination=event["inc"])
 
                 # update the velocity of the current PhaseSpacePosition
                 current_w0 = gd.PhaseSpacePosition(pos=current_w0.pos,

--- a/cogsworth/kicks.py
+++ b/cogsworth/kicks.py
@@ -9,7 +9,7 @@ import astropy.units as u
 __all__ = ["get_kick_differential", "integrate_orbit_with_events"]
 
 
-def get_kick_differential(delta_v_sys_xyz, m_1, m_2, a):
+def get_kick_differential(delta_v_sys_xyz, phase=None, inclination=None):
     """Calculate the :class:`~astropy.coordinates.CylindricalDifferential` from a combination of the natal
     kick, Blauuw kick and orbital motion.
 
@@ -18,29 +18,19 @@ def get_kick_differential(delta_v_sys_xyz, m_1, m_2, a):
     delta_v_sys_xyz : :class:`~astropy.units.Quantity` [velocity]
         Change in systemic velocity due to natal and Blauuw kicks in BSE :math:`(v_x, v_y, v_z)` frame
         (see Fig A1 of `Hurley+02 <https://ui.adsabs.harvard.edu/abs/2002MNRAS.329..897H/abstract>`_)
-    m_1 : :class:`~astropy.units.Quantity` [mass]
-        Primary mass
-    m_2 : :class:`~astropy.units.Quantity` [mass]
-        Secondary Mass
-    a : :class:`~astropy.units.Quantity` [length]
-        Binary separation
+    phase : `float`
+        Orbital phase angle in radians
+    inclination : `float`
+        Inclination to the Galactic plane in radians
 
     Returns
     -------
     kick_differential : :class:`~astropy.coordinates.CylindricalDifferential`
         Kick differential
     """
-    # TODO: Check whether this should be included but it seems not
-    # calculate the orbital velocity ASSUMING A CIRCULAR ORBIT
-    # if a.value > 0.0:
-    #     v_orb = np.sqrt(const.G * (m_1 + m_2) / a)
-
-    #     # adjust change in velocity by orbital motion of supernova star
-    #     delta_v_sys_xyz -= v_orb
-
     # orbital phase angle and inclination to Galactic plane
-    theta = np.random.uniform(0, 2 * np.pi)
-    phi = np.random.uniform(0, 2 * np.pi)
+    theta = np.random.uniform(0, 2 * np.pi) if phase is None else phase
+    phi = np.random.uniform(0, 2 * np.pi) if inclination is None else inclination
 
     # rotate BSE (v_x, v_y, v_z) into Galactocentric (v_X, v_Y, v_Z)
     v_X = delta_v_sys_xyz[0] * np.cos(theta) - delta_v_sys_xyz[1] * np.sin(theta) * np.cos(phi)\

--- a/cogsworth/pop.py
+++ b/cogsworth/pop.py
@@ -790,6 +790,11 @@ class Population():
                                     vel=[a.to(u.km/u.s).value for a in [v_X, v_Y,
                                                                         self.initial_galaxy.v_z]] * u.km/u.s)
 
+        # randomly drawn phase and inclination angles as necessary
+        for col in ["phase_sn_1", "phase_sn_2", "inc_sn_1", "inc_sn_2"]:
+            if col not in self.initC:
+                self.initC[col] = np.random.uniform(0, 2 * np.pi, len(self.initC))
+
         # identify the pertinent events in the evolution
         primary_events, secondary_events = identify_events(p=self)
 

--- a/cogsworth/tests/test_events.py
+++ b/cogsworth/tests/test_events.py
@@ -21,7 +21,7 @@ class Test(unittest.TestCase):
             "sep": [10, 10, 10, -1.0, 10, 10, -1.0],
             "ecc": [0, 0, 0, -1.0, 0, 0.1, -1.0],
             "evol_type": [-1, 15, 15, 11, 15, 16, 11],
-            "bin_num": [1, 2, 3, 3, 4, 4, 4],
+            "bin_num": [0, 1, 2, 2, 3, 3, 3],
         }
         bpp = pd.DataFrame(data=bpp_dict)
         bpp.set_index("bin_num", drop=False, inplace=True)
@@ -35,7 +35,7 @@ class Test(unittest.TestCase):
             "delta_vsysx_2": [0, 0, 0, 0, 0],
             "delta_vsysy_2": [0, 0, 0, 0, 0],
             "delta_vsysz_2": [0, 0, 0, 0, 0],
-            "bin_num": [1, 2, 3, 4, 4],
+            "bin_num": [0, 1, 2, 3, 3],
         }
         kick_info = pd.DataFrame(data=kick_info_dict)
         kick_info.set_index("bin_num", drop=False, inplace=True)

--- a/cogsworth/tests/test_kicks.py
+++ b/cogsworth/tests/test_kicks.py
@@ -35,3 +35,16 @@ class Test(unittest.TestCase):
                 valid_orbit[i] = False
 
         self.assertTrue(np.all(valid_orbit))
+
+    def test_saved_inc_phase(self):
+        """Test that the inclination and phase are saved correctly in the kick events - such that the same
+        population at present day is fully recreated"""
+
+        p = cogsworth.pop.Population(5, final_kstar1=[13, 14], processes=1, BSE_settings={"binfrac": 1.0})
+        p.create_population()
+        first_pos = p.final_pos.copy()
+
+        p.perform_galactic_evolution()
+        second_pos = p.final_pos.copy()
+
+        self.assertTrue(np.allclose(first_pos, second_pos))


### PR DESCRIPTION
Inclinations and phases are now all drawn together (faster!) and saved in the initC table (reproducible!). The new columns are `phase_sn_X` and `inc_sn_X` which are the phase and inclination at the moment of SN `X` where `X` is 1 or 2.

This will fix #114 .